### PR TITLE
added store github insights example

### DIFF
--- a/fal_scripts/fal_github_insights.py
+++ b/fal_scripts/fal_github_insights.py
@@ -5,10 +5,10 @@ import certifi
 from io import BytesIO
 import pandas as pd
 
-ACCESS_TOKEN = os.environ['GITHUB_TOKEN']
+GITHUB_ACCESS_TOKEN = os.environ['GITHUB_TOKEN']
 
 g_url = 'https://api.github.com/repos/fal-ai/fal/traffic/'
-header_list = [f'Authorization: token {ACCESS_TOKEN}']
+header_list = [f'Authorization: token {GITHUB_ACCESS_TOKEN}']
 metrics = {'clones': '', 'views': '', 'popular/paths': '', 'popular/referrers': ''}
 
 for metric in metrics.keys():

--- a/fal_scripts/fal_github_insights.py
+++ b/fal_scripts/fal_github_insights.py
@@ -4,6 +4,7 @@ import json
 import certifi
 from io import BytesIO
 import pandas as pd
+from sqlalchemy import except_
 
 GITHUB_ACCESS_TOKEN = os.environ['GITHUB_TOKEN']
 
@@ -23,6 +24,9 @@ for metric in metrics.keys():
     metrics[metric] = buffer.getvalue().decode('utf-8')
     metrics[metric] = json.loads(metrics[metric])
 
+fal_views_dates_p = source('fal_github_insights', 'fal_views_dates')
+fal_clones_dates_p = source('fal_github_insights', 'fal_clones_dates')
+
 fal_views = pd.DataFrame.from_dict(metrics['views']['views'])
 fal_clones = pd.DataFrame.from_dict(metrics['clones']['clones'])
 fal_ppaths = pd.DataFrame.from_dict(metrics['popular/paths'])
@@ -32,10 +36,34 @@ fal_views['timestamp'] = fal_views['timestamp'].transform(lambda x: pd.Timestamp
 fal_clones['timestamp'] = fal_clones['timestamp'].transform(lambda x: pd.Timestamp(x))
 fal_ppaths = fal_ppaths.drop('title', 1)
 
-write_to_source(fal_views, 'fal_github_insights', 'fal_views')
-write_to_source(fal_clones, 'fal_github_insights', 'fal_clones')
-write_to_source(fal_ppaths, 'fal_github_insights', 'fal_ppaths')
-write_to_source(fal_preferrers, 'fal_github_insights', 'fal_preferrers')
+fal_views = fal_views.sort_values(by='timestamp')
+fal_clones = fal_clones.sort_values(by='timestamp')
+
+fal_views_dates = {'start': [fal_views['timestamp'].min()], 'end': [fal_views['timestamp'].max()]}
+fal_clones_dates = {'start': [fal_clones['timestamp'].min()], 'end': [fal_clones['timestamp'].max()]}
+fal_views_dates = pd.DataFrame.from_dict(fal_views_dates)
+fal_clones_dates = pd.DataFrame.from_dict(fal_clones_dates)
+
+write_to_source(fal_ppaths, 'fal_github_insights', 'fal_ppaths', mode='overwrite')
+write_to_source(fal_preferrers, 'fal_github_insights', 'fal_preferrers', mode='overwrite')
+
+write_to_source(fal_views_dates, 'fal_github_insights', 'fal_views_dates', mode='overwrite')
+write_to_source(fal_clones_dates, 'fal_github_insights', 'fal_clones_dates', mode='overwrite')
+    
+if fal_views_dates['start'][0] > fal_views_dates_p['end'][0]:
+    write_to_source(fal_views, 'fal_github_insights', 'fal_views')
+    write_to_source(fal_clones, 'fal_github_insights', 'fal_clones')
+else:
+    try:
+        i = fal_views.loc[fal_views['timestamp'] == fal_views_dates_p['end']] + 1
+        write_to_source(fal_views[i:], 'fal_github_insights', 'fal_views')
+    except:
+        print('no update')
+    try:
+        i = fal_clones.loc[fal_clones['timestamp'] == fal_clones_dates_p['end']] + 1
+        write_to_source(fal_clones[i:], 'fal_github_insights', 'fal_clones')
+    except:
+        print('no update')
 
 # append data: fal_views, fal_clones
 # update data: fal_ppaths, fal_preferrers

--- a/fal_scripts/fal_github_insights.py
+++ b/fal_scripts/fal_github_insights.py
@@ -1,0 +1,38 @@
+import os
+import pycurl
+import json
+import certifi
+from io import BytesIO
+import pandas as pd
+
+ACCESS_TOKEN = os.environ['GITHUB_TOKEN']
+
+g_url = 'https://api.github.com/repos/fal-ai/fal/traffic/'
+header_list = [f'Authorization: token {ACCESS_TOKEN}']
+metrics = {'clones': '', 'views': '', 'popular/paths': '', 'popular/referrers': ''}
+
+for metric in metrics.keys():
+    buffer = BytesIO()
+    c = pycurl.Curl()
+    c.setopt(c.URL, g_url+metric)
+    c.setopt(c.HTTPHEADER, header_list)
+    c.setopt(c.WRITEDATA, buffer)
+    c.setopt(c.CAINFO, certifi.where())
+    c.perform()
+    c.close()
+    metrics[metric] = buffer.getvalue().decode('utf-8')
+    metrics[metric] = json.loads(metrics[metric])
+
+fal_views = pd.DataFrame.from_dict(metrics['views']['views'])
+fal_clones = pd.DataFrame.from_dict(metrics['clones']['clones'])
+fal_ppaths = pd.DataFrame.from_dict(metrics['popular/paths'])
+fal_preferrers = pd.DataFrame.from_dict(metrics['popular/referrers'])
+
+fal_views['timestamp'] = fal_views['timestamp'].transform(lambda x: pd.Timestamp(x))
+fal_clones['timestamp'] = fal_clones['timestamp'].transform(lambda x: pd.Timestamp(x))
+fal_ppaths = fal_ppaths.drop('title', 1)
+
+write_to_source(fal_views, 'fal_github_insights', 'fal_views')
+write_to_source(fal_clones, 'fal_github_insights', 'fal_clones')
+write_to_source(fal_ppaths, 'fal_github_insights', 'fal_ppaths')
+write_to_source(fal_preferrers, 'fal_github_insights', 'fal_preferrers')

--- a/fal_scripts/fal_github_insights.py
+++ b/fal_scripts/fal_github_insights.py
@@ -36,3 +36,6 @@ write_to_source(fal_views, 'fal_github_insights', 'fal_views')
 write_to_source(fal_clones, 'fal_github_insights', 'fal_clones')
 write_to_source(fal_ppaths, 'fal_github_insights', 'fal_ppaths')
 write_to_source(fal_preferrers, 'fal_github_insights', 'fal_preferrers')
+
+# append data: fal_views, fal_clones
+# update data: fal_ppaths, fal_preferrers

--- a/models/fal_clones_model.sql
+++ b/models/fal_clones_model.sql
@@ -1,0 +1,1 @@
+SELECT * FROM `learning-project-305919.dbt_meder.fal_clones`

--- a/models/fal_clones_model.sql
+++ b/models/fal_clones_model.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `learning-project-305919.dbt_meder.fal_clones`
+SELECT * FROM {{ source('fal_github_insights', 'fal_clones') }}

--- a/models/fal_ppaths_model.sql
+++ b/models/fal_ppaths_model.sql
@@ -1,0 +1,1 @@
+SELECT * FROM `learning-project-305919.dbt_meder.fal_ppaths`

--- a/models/fal_ppaths_model.sql
+++ b/models/fal_ppaths_model.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `learning-project-305919.dbt_meder.fal_ppaths`
+SELECT * FROM {{ source('fal_github_insights', 'fal_ppaths') }}

--- a/models/fal_preferrers_model.sql
+++ b/models/fal_preferrers_model.sql
@@ -1,0 +1,1 @@
+SELECT * FROM `learning-project-305919.dbt_meder.fal_preferrers`

--- a/models/fal_preferrers_model.sql
+++ b/models/fal_preferrers_model.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `learning-project-305919.dbt_meder.fal_preferrers`
+SELECT * FROM {{ source('fal_github_insights', 'fal_preferrers') }}

--- a/models/fal_views_model.sql
+++ b/models/fal_views_model.sql
@@ -1,0 +1,1 @@
+SELECT * FROM `learning-project-305919.dbt_meder.fal_views`

--- a/models/fal_views_model.sql
+++ b/models/fal_views_model.sql
@@ -1,1 +1,1 @@
-SELECT * FROM `learning-project-305919.dbt_meder.fal_views`
+SELECT * FROM {{ source('fal_github_insights', 'fal_views') }}

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -14,6 +14,8 @@ sources:
       - name: fal_clones
       - name: fal_ppaths
       - name: fal_preferrers
+      - name: fal_views_dates
+      - name: fal_clones_dates
 
 models:
   - name: boston
@@ -167,6 +169,14 @@ models:
             type: string
     config:
       materialized: table
+    meta:
+      owner: "@omer"
+  - name: fal_views_dates_m
+    description: fdal
+    meta:
+      owner: "@omer"
+  - name: fal_clones_dates_m
+    description: fdal
     meta:
       owner: "@omer"
 

--- a/models/schema.yml
+++ b/models/schema.yml
@@ -6,6 +6,14 @@ sources:
     schema: "{{ env_var('BQ_DATASET') }}"
     tables:
       - name: ticket_data_sentiment_analysis
+  - name: fal_github_insights
+    database: "{{ env_var('GCLOUD_PROJECT') }}"
+    schema: "{{ env_var('BQ_DATASET') }}"
+    tables:
+      - name: fal_views
+      - name: fal_clones
+      - name: fal_ppaths
+      - name: fal_preferrers
 
 models:
   - name: boston
@@ -47,6 +55,120 @@ models:
       fal:
         scripts:
           - fal_scripts/anomaly_detection.py
+  - name: fal_views_model
+    description: fal-ai/fal Github Views
+    columns:
+      - name: count
+        description: Total views in one day
+        meta:
+          dimension:
+            type: number
+          metrics:
+            daily_views:
+              type: number
+            total_views:
+              type: sum
+      - name: uniques
+        description: Total unique views in one day
+        meta:
+          dimension:
+            type: number
+          metrics:
+            daily_unique_views:
+              type: number
+      - name: timestamp
+        description: Total views in one day
+        meta:
+          dimension:
+            type: timestamp
+    config:
+      materialized: table
+    meta:
+      owner: "@omer"
+      fal:
+        scripts:
+          before:
+            - fal_scripts/fal_github_insights.py
+  - name: fal_clones_model
+    description: fal-ai/fal Github Clones
+    columns:
+      - name: count
+        description: Total clones in one day
+        meta:
+          dimension:
+            type: number
+          metrics:
+            daily_clones:
+              type: number
+            total_clones:
+              type: sum
+      - name: uniques
+        description: Total unique clones in one day
+        meta:
+          dimension:
+            type: number
+          metrics:
+            daily_unique_clones:
+              type: number
+      - name: timestamp
+        description: Total clones in one day
+        meta:
+          dimension:
+            type: timestamp
+    config:
+      materialized: table
+    meta:
+      owner: "@omer"
+  - name: fal_ppaths_model
+    description: fal-ai/fal Github Popular Paths
+    columns:
+      - name: count
+        description: Total page views in the last 14 days
+        meta:
+          dimension:
+            type: number
+      - name: uniques
+        description: Total unique page views in the last 14 days
+        meta:
+          dimension:
+            type: number
+          metrics:
+            most_popular_path:
+              type: number
+      - name: path
+        description: Popular pages of fal
+        meta:
+          dimension:
+            type: string
+    config:
+      materialized: table
+    meta:
+      owner: "@omer"
+  - name: fal_preferrers_model
+    description: fal-ai/fal Github Popular Referrers
+    columns:
+      - name: count
+        description: Total visitors from the referrer in the last 14 days
+        meta:
+          dimension:
+            type: number
+      - name: uniques
+        description: Total unique visitors from the referrer in the last 14 days
+        meta:
+          dimension:
+            type: number
+          metrics:
+            most_popular_path:
+              type: number
+      - name: referrer
+        description: Referrer sites to fal
+        meta:
+          dimension:
+            type: string
+    config:
+      materialized: table
+    meta:
+      owner: "@omer"
 
 fal:
   scripts:


### PR DESCRIPTION
added models, python scripts and modified the schema to store historical github insights of fal-ai/fal and visualizing them with lightdash using fal run --before